### PR TITLE
Add UPDATE_TYPE setting to allow for timestamp updates

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,7 @@
+This application is written in Go.
+
+The code is intended to be simple, everything contained in the main.go file with minimal dependencies.
+
+The application itself runs as a Docker container as defined by the Dockerfile in the repo.  This is intended to run as a Cloud Run Job.
+
+The README.md file provides an overview for the application including the environment variables for configuring the application.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ This application runs scanning through the collection, updating each document at
 - `ATOMIC_UPDATES` – Use atomic transactions for updates (ensures document existence, default: false)
 - `UPDATE_TYPE` – Defines how the field is updated. Possible values:
   - `INCREMENT` (default): Atomically increments the numeric field by 1.
-  - `START_TIMESTAMP`: Sets the field to the same UTC timestamp (ISO 8601) captured at the start of execution.
-  - `CURRENT_TIMESTAMP`: Sets the field to the current UTC timestamp (ISO 8601) for each document as it is updated.
+  - `START_TIMESTAMP`: Sets the field to the same UTC timestamp captured at the start of execution.
+  - `CURRENT_TIMESTAMP`: Sets the field to the current UTC timestamp for each document as it is updated.
 - `GOOGLE_APPLICATION_CREDENTIALS` – (Optional) Path to the service account JSON file. If not set, Application Default Credentials (ADC) will be used (e.g., when running in Cloud Run Jobs with an attached service account).

--- a/README.md
+++ b/README.md
@@ -20,4 +20,8 @@ This application runs scanning through the collection, updating each document at
 - `BATCH_SIZE` – Number of documents per batch (default: 100)  
 - `RATE_LIMIT` – Maximum updates per second (default: 50)
 - `ATOMIC_UPDATES` – Use atomic transactions for updates (ensures document existence, default: false)
+- `UPDATE_TYPE` – Defines how the field is updated. Possible values:
+  - `INCREMENT` (default): Atomically increments the numeric field by 1.
+  - `START_TIMESTAMP`: Sets the field to the same UTC timestamp (ISO 8601) captured at the start of execution.
+  - `CURRENT_TIMESTAMP`: Sets the field to the current UTC timestamp (ISO 8601) for each document as it is updated.
 - `GOOGLE_APPLICATION_CREDENTIALS` – (Optional) Path to the service account JSON file. If not set, Application Default Credentials (ADC) will be used (e.g., when running in Cloud Run Jobs with an attached service account).


### PR DESCRIPTION
This was implemented using GitHub Copilot Agent mode using o4-mini with the following prompt...

```
This application needs to be enhanced with a new envirionment variable UPDATE_TYPE which defines how the attributes are updated.

There are three possible values for this.
INCREMENT which is the current behavior and default if the envirionment variable is not specified. The field is updated by incrementing an integer.
START_TIMESTAMP updates the records with the timestamp using the appropriate Firestore date time that is determined at the start of the execution. Therefore all records end up with the same timestamp.
CURRENT_TIMESTAMP updates the records as they are itterated through the records meaning each one will have a different timestamp based on how long it takes to loop through the records.

Be sure to update both the code and the README file.

Always use ISO 8601 format: 2019-11-14T00:55:31.820Z
```